### PR TITLE
updated binRoutes to connect to psql

### DIFF
--- a/controllers/binRoutes.js
+++ b/controllers/binRoutes.js
@@ -1,24 +1,43 @@
 const binRoutes = require("express").Router();
-let pool;
-
-if (process.env.NODE_ENV === "production") {
-  pool = require("../pool");
-} else if (process.env.NODE_ENV === "development") {
-  const { Pool } = require("pg");
-  pool = new Pool();
-}
+const jsonStringifySafe = require("json-stringify-safe");
+// above package is needed to stringify the http request due to request containing circular references and throwing an error
+const pool = require("../pool");
+const URL = process.env.ENDPOINT;
 
 binRoutes.get("/", async (req, res) => {
-  const results = await pool.query("SELECT NOW()"); // testing query
-  await pool.end();
-  res.send(results);
+  //get the id from the bin table of our current endpoint (whose url is in the .env file)
+  const sql = "SELECT id FROM bin WHERE endpoint=$1";
+  const result = await pool.query(sql, [URL]);
+  const id = result.rows[0].id;
+  // get the payload data from the  payload table with the current url
+  const sql2 = "SELECT http_request FROM payload WHERE bin_id=$1";
+  const payloadRequests = await pool.query(sql2, [String(id)]);
+  // sent the payload data to the frontend
+  res.send(payloadRequests.rows);
 });
+
 binRoutes.get("/$uuid", (req, res) => {
+  // possible route if there will be multiple url's the app can have webhooks send to
   // get info from db and send in response
 });
 
-binRoutes.post("/$uuid", (req, res) => {
-  // take sent data and put into the DB
+binRoutes.post("/", async (req, res) => {
+  // get the ID from the bin table
+  const sql = "SELECT id FROM bin WHERE endpoint=$1";
+  const result = await pool.query(sql, [URL]);
+  const id = result.rows[0].id;
+  // get the timestamp from the request
+  const timeStamp = req.body.repository.updated_at;
+  // safely stringify the request
+  req = jsonStringifySafe(req);
+  // insert the request into the payload table
+  const sql2 = `INSERT INTO payload (http_request, http_timestamp, bin_id) VALUES ($1, $2, $3) RETURNING http_request`;
+  await pool.query(sql2, [req, timeStamp, id]);
+
+  /*
+  needed functionality:
+    send the payload data to the build(frontend) to diplay the most recent webhook request or simply tell the frontend to update its display by sending a GET request.
+  */
 });
 
 module.exports = binRoutes;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const app = require("./app");
 require("dotenv").config();
+const app = require("./app");
 
 const PORT = process.env.BACKEND_PORT;
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "morgan": "^1.10.0",
-    "pg": "^8.10.0"
+    "pg": "^8.10.0",
+    "json-stringify-safe": "5.0.1"
   },
   "devDependencies": {
     "eslint": "^8.32.0",

--- a/schema.sql
+++ b/schema.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS bin (
   id       serial PRIMARY KEY,
-  endpoint varchar(20) UNIQUE NOT NULL
+  endpoint varchar(255) UNIQUE NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS payload (
-  id serial      PRIMARY KEY,
-  http_request   json,
+  id             serial PRIMARY KEY,
+  http_request  JSON,
   http_timestamp timestamp NOT NULL,
-  bin_id         integer NOT NULL REFERENCES bin (id) ON DELETE CASCADE
+  bin_id         int NOT NULL REFERENCES bin (id) ON DELETE CASCADE
 );


### PR DESCRIPTION
binRoutes has been updated to work with postgres, but will need a URL variable in the .env (this will need to change if we start using different paths/users/urls, but works well at the moment because we only have one url as the receiving end of a webhook request)
a few minor changes to the sql tables
The payload from gitHub is gigantic and definitely needs to be parsed, but right now no parsing is in place, just raw data in the sql table.
